### PR TITLE
v1.1.0: extract and grade commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,10 +82,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -174,16 +192,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
@@ -193,6 +255,26 @@ checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -217,10 +299,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -239,6 +378,12 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
@@ -299,10 +444,26 @@ dependencies = [
  "clap",
  "colored",
  "itertools",
+ "open",
  "rayon",
  "regex",
  "serde",
+ "serde_json",
  "serde_yaml",
+ "tempfile",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -310,6 +471,12 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -329,6 +496,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -362,10 +541,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -378,6 +576,58 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-sys"
@@ -451,3 +701,91 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rufus"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rufus"
 
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ rayon = "1.10.0"
 regex = "1.11.1"
 serde = { version = "1.0.216", features = ["derive"] }
 serde_yaml = "0.9.34"
+serde_json = "1.0"
+open = "5"
+
+[dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -1,69 +1,196 @@
 # Rufus
 
-A general-purpose tool for detecting cheating in autograded Gradescope code submissions by cross-referencing emissions of values that ought to be unique class-wide.
+A general-purpose CLI for working with [Gradescope](https://www.gradescope.com) submission exports. It can detect plagiarism across autograded submissions, extract embedded file data, and walk submissions for manual grading.
 
 ## Pre-built Binaries (Recommended)
 
-You can download pre-built binaries for Linux, macOS, and Windows from the [GitHub Releases page](https://github.com/UF-Comp-Linear-Algebra/Rufus/releases).
+Download pre-built binaries for Linux, macOS, and Windows from the [GitHub Releases page](https://github.com/UF-Comp-Linear-Algebra/Rufus/releases).
 
 - **Linux:** `rufus-linux`
 - **macOS:** `rufus-macos`
 - **Windows:** `rufus-windows.exe`
 
-### Usage
+On Linux/macOS, make it executable before use:
 
-1. Download the appropriate binary for your platform.
-2. On Linux/macOS, make it executable:
-   ```bash
-   chmod +x rufus-<platform>
-   ```
-3. Run the binary from your terminal:
-   ```bash
-   ./rufus-<platform> [SUBCOMMAND] [ARGS]
-   ```
-4. For help and available commands:
-   ```bash
-   ./rufus-<platform> --help
-   ```
+```bash
+chmod +x rufus-<platform>
+./rufus-<platform> --help
+```
 
-See the [Releases page](https://github.com/UF-Comp-Linear-Algebra/Rufus/releases) for the latest version.
+---
+
+## Commands
+
+### `count`
+
+Count the number of submissions across one or more export files.
+
+```bash
+rufus count submissions.yml
+```
+
+---
+
+### `hunt`
+
+Detect plagiarism by finding groups of submissions that share identical emissions.
+
+```bash
+rufus hunt submissions.yml [OPTIONS]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--group-size N` | `-k` | Number of emissions that must match (default: max found) |
+| `--min-size N` | `-m` | Minimum group size to display (default: 2) |
+| `--show-emissions` | `-S` | Print the matching emissions for each group |
+| `--exact` | `-E` | Only show groups matching exactly on k emissions |
+
+```bash
+# Find groups sharing any 3 emissions, show the matching values
+rufus hunt submissions.yml -k 3 --show-emissions
+```
+
+---
+
+### `extract`
+
+Extract `extra_data` fields from Gradescope export files — as displayed text or written to files.
+
+```bash
+rufus extract submissions.yml [OPTIONS]
+```
+
+#### Key specification
+
+Use `--key name[:decode[:ext]]` to select a field and optionally decode it:
+
+| Example | Meaning |
+|---------|---------|
+| `--key level_uf2` | Raw value |
+| `--key level_uf2:base64:uf2` | Base64-decode, save as `.uf2` |
+| `--key checksum:hex` | Hex-decode |
+| `--key checksum::sha256` | Raw value, save as `.sha256` |
+
+`decode` can be `raw` (or empty), `base64`, `base64url`, or `hex`. Omit `--key` entirely to extract all available keys.
+
+#### Output options
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--output DIR` | `-o` | Write files to DIR (default: print to stdout) |
+| `--alongside` | `-A` | Write files into the same directory as each source YAML |
+| `--layout` | | `dir` (subdirectory per submission, default) or `flat` (prefixed filenames) |
+| `--name-by` | | `submission_id` (default), `name`, `email`, or `sid` |
+| `--dry-run` | | Show paths that would be written without writing |
+
+`--alongside` and `--output` are mutually exclusive.
+
+#### Filtering options
+
+| Flag | Description |
+|------|-------------|
+| `--list` | List all available keys and exit |
+| `--skip-missing` | Skip submissions that don't have all selected keys |
+| `--missing-only` | Report which submissions are missing selected keys |
+
+```bash
+# List available keys
+rufus extract submissions.yml --list
+
+# Extract a base64-encoded UF2 file for each submission into ./out/
+rufus extract submissions.yml --key level_uf2:base64:uf2 -o ./out/
+
+# Write files alongside the source YAML, skip submissions with missing keys
+rufus extract submissions.yml --key level_uf2:base64:uf2 -A --skip-missing
+
+# Preview what would be written
+rufus extract submissions.yml --key level_uf2:base64:uf2 -o ./out/ --dry-run
+```
+
+---
+
+### `grade`
+
+Walk a directory of extracted submissions, open each one's Gradescope grading page in the browser, and track progress so you can resume later.
+
+```bash
+rufus grade <DIR> --course <ID> --assignment <ID> [OPTIONS]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--course ID` | `-c` | Gradescope course ID |
+| `--assignment ID` | `-a` | Gradescope assignment ID |
+| `--export FILE` | `-e` | Export YAML to show submitter names |
+| `--cmd TEMPLATE` | `-x` | Command to run once per submission |
+| `--state FILE` | `-s` | State file path (default: `<DIR>/.rufus-grade`) |
+| `--reset` | | Ignore existing state and start over |
+
+The grader opens `https://www.gradescope.com/courses/{course}/assignments/{assignment}/submissions/{id}` for each submission directory named `submission_{id}`. Progress is saved after each submission so you can quit and resume with the same command (without `<DIR>`, `--course`, or `--assignment` — they are read from the state file).
+
+#### Command templates
+
+`--cmd` supports two placeholders:
+
+| Placeholder | Expands to |
+|-------------|-----------|
+| `{dir}` | Absolute path to the submission directory |
+| `{file:name}` | `{dir}/name` |
+
+```bash
+# Flash a UF2 file and open the grading page for each submission
+rufus grade ./out/ -c 1217863 -a 7420607 \
+  --export submissions.yml \
+  --cmd "picotool load {file:level_uf2.uf2}"
+```
+
+#### Interactive prompt
+
+```
+[Enter] done  [s] skip  [r] re-run  [b] back  [q] quit
+```
+
+#### Typical workflow
+
+```bash
+# 1. Extract UF2 files from a Gradescope export
+rufus extract submissions.yml --key level_uf2:base64:uf2 -o ./uf2s/
+
+# 2. Grade each submission (flash hardware, open browser)
+rufus grade ./uf2s/ -c 1217863 -a 7420607 \
+  --export submissions.yml \
+  --cmd "picotool load {file:level_uf2.uf2}"
+
+# 3. Resume later — state is loaded automatically
+rufus grade --state ./uf2s/.rufus-grade --export submissions.yml \
+  --cmd "picotool load {file:level_uf2.uf2}"
+```
 
 ---
 
 ## Development
 
-If you want to build or modify Rufus, follow these instructions:
-
 ### Prerequisites
 
-- [Rust](https://www.rust-lang.org/tools/install) (install via [rustup.rs](https://www.rust-lang.org/tools/install))
+- [Rust](https://www.rust-lang.org/tools/install) (install via `rustup`)
 
-### Building from Source
-
-Clone the repository and build the project:
+### Building
 
 ```bash
 git clone https://github.com/UF-Comp-Linear-Algebra/Rufus.git
-cd <repo>
+cd Rufus
 cargo build --release
 ```
 
-### Running from Source
-
-You can run Rufus directly with Cargo:
+### Running
 
 ```bash
 cargo run --release -- [SUBCOMMAND] [ARGS]
 ```
 
-For example, to hunt for cheating submissions:
+### Testing
 
 ```bash
-cargo run --release -- hunt [FILES] --show-emissions
-```
-
-For help and available commands:
-
-```bash
-cargo run --release -- --help
+cargo test
 ```

--- a/src/cli/clap.rs
+++ b/src/cli/clap.rs
@@ -1,7 +1,9 @@
 use camino::Utf8PathBuf;
 use clap::{
-    command, crate_authors, crate_description, crate_name, crate_version, Parser, Subcommand,
+    crate_authors, crate_description, crate_name, crate_version, Parser, Subcommand,
 };
+
+use crate::extract::{parse_key_spec, KeySpec, Layout, NameBy};
 
 #[derive(Parser)]
 #[command(name = crate_name!(), author=crate_authors!())]
@@ -48,5 +50,64 @@ pub enum Command {
             help = "Only show groups that match exactly on k emissions (removes k+1 group submissions from the k groups)."
         )]
         exact: bool,
+    },
+
+    #[command(about = "Extract extra_data fields from Gradescope export files")]
+    Extract {
+        #[clap(required = true)]
+        #[arg(name = "export files")]
+        filepaths: Vec<Utf8PathBuf>,
+
+        #[arg(
+            long = "key",
+            value_name = "NAME[:DECODE[:EXT]]",
+            value_parser = parse_key_spec,
+            help = "Key to extract. Format: name[:decode[:ext]] (e.g. level_uf2:base64:uf2, checksum::sha256). Repeatable. Default: all keys."
+        )]
+        keys: Vec<KeySpec>,
+
+        #[arg(
+            long,
+            short = 'o',
+            help = "Output directory. If omitted, values are printed to stdout instead of written to files."
+        )]
+        output: Option<Utf8PathBuf>,
+
+        #[arg(
+            long,
+            default_value = "dir",
+            help = "Output layout: 'dir' creates a subdirectory per submission; 'flat' uses prefixed filenames"
+        )]
+        layout: Layout,
+
+        #[arg(
+            long,
+            default_value = "submission_id",
+            value_name = "FIELD",
+            help = "How to name submissions: submission_id, name, email, or sid"
+        )]
+        name_by: NameBy,
+
+        #[arg(long, default_value = "false", help = "List all available keys across submissions and exit")]
+        list: bool,
+
+        #[arg(
+            long,
+            default_value = "false",
+            conflicts_with = "missing_only",
+            help = "Skip submissions that are missing any selected key"
+        )]
+        skip_missing: bool,
+
+        #[arg(
+            long,
+            default_value = "false",
+            conflicts_with = "skip_missing",
+            help = "Only report which submissions are missing selected keys; do not write files"
+        )]
+        missing_only: bool,
+
+        #[arg(long, default_value = "false", help = "Show what would be written without writing anything")]
+        dry_run: bool,
     },
 }

--- a/src/cli/clap.rs
+++ b/src/cli/clap.rs
@@ -5,6 +5,7 @@ use clap::{
 
 use crate::extract::{parse_key_spec, KeySpec, Layout, NameBy};
 
+
 #[derive(Parser)]
 #[command(name = crate_name!(), author=crate_authors!())]
 #[command(version=crate_version!(), propagate_version=true)]
@@ -109,5 +110,43 @@ pub enum Command {
 
         #[arg(long, default_value = "false", help = "Show what would be written without writing anything")]
         dry_run: bool,
+
+        #[arg(
+            long,
+            short = 'A',
+            default_value = "false",
+            conflicts_with = "output",
+            help = "Write files alongside each source YAML (implies file output)"
+        )]
+        alongside: bool,
+    },
+
+    #[command(about = "Walk extracted submissions and open Gradescope grading pages")]
+    Grade {
+        #[arg(help = "Directory of extracted submissions. Required on first run; loaded from state file on resume.")]
+        dir: Option<Utf8PathBuf>,
+
+        #[arg(long, short = 'c', help = "Gradescope course ID. Required on first run; loaded from state file on resume.")]
+        course: Option<String>,
+
+        #[arg(long, short = 'a', help = "Gradescope assignment ID. Required on first run; loaded from state file on resume.")]
+        assignment: Option<String>,
+
+        #[arg(long, short = 'e', help = "Gradescope export YAML to show submitter names")]
+        export: Option<Utf8PathBuf>,
+
+        #[arg(
+            long,
+            short = 'x',
+            value_name = "TEMPLATE",
+            help = "Command to run once per submission. Supports {dir} and {file:name} placeholders."
+        )]
+        cmd: Option<String>,
+
+        #[arg(long, short = 's', help = "Resume state file (default: <dir>/.rufus-grade)")]
+        state: Option<Utf8PathBuf>,
+
+        #[arg(long, help = "Ignore existing state and start over")]
+        reset: bool,
     },
 }

--- a/src/cli/handlers.rs
+++ b/src/cli/handlers.rs
@@ -6,6 +6,7 @@ use colored::Colorize;
 
 use crate::{
     cli::utils::print_group,
+    extract::{compute_label, decode_value, stringify_yaml_value, Decode, DecodeOutput, KeySpec, Layout, NameBy},
     gradescope::{
         loaders::{load_export, load_exports},
         types::{LatestSubmission, SubmissionTrait},
@@ -83,6 +84,213 @@ pub fn handle_hunt(
     // PRINTING
     for (i, grouping) in groups.iter().enumerate() {
         print_group(i + 1, grouping, *show_emissions);
+    }
+}
+
+pub fn handle_extract(
+    filepaths: &Vec<Utf8PathBuf>,
+    key_specs: &Vec<KeySpec>,
+    output: &Option<Utf8PathBuf>,
+    layout: &Layout,
+    name_by: &NameBy,
+    list: bool,
+    skip_missing: bool,
+    missing_only: bool,
+    dry_run: bool,
+) {
+    let submissions: Vec<(String, LatestSubmission)> = filepaths
+        .iter()
+        .flat_map(|fp| {
+            print!("Parsing file {}... ", fp);
+            match load_export(fp) {
+                Ok(export) => {
+                    println!("{}", "DONE".green());
+                    Some(export)
+                }
+                Err(_) => {
+                    println!("{}", "FAILED".red());
+                    None
+                }
+            }
+        })
+        .flat_map(|e| e.into_iter())
+        .collect();
+
+    if submissions.is_empty() {
+        eprintln!("No submissions loaded.");
+        return;
+    }
+    println!();
+
+    // Collect all extra_data keys present across all submissions
+    let all_keys: BTreeSet<String> = submissions
+        .iter()
+        .flat_map(|(_, s)| s.extra_data_map().into_keys())
+        .collect();
+
+    if list {
+        println!(
+            "Found {} key(s) across {} submission(s):\n",
+            all_keys.len(),
+            submissions.len()
+        );
+        for key in &all_keys {
+            let count = submissions
+                .iter()
+                .filter(|(_, s)| s.extra_data_map().contains_key(key))
+                .count();
+            println!("  {}  ({}/{})", key, count, submissions.len());
+        }
+        if !all_keys.is_empty() {
+            let flags = all_keys
+                .iter()
+                .map(|k| format!("--key {}", k))
+                .collect::<Vec<_>>()
+                .join(" ");
+            println!("\nSuggested flags:\n  {}", flags);
+        }
+        return;
+    }
+
+    // Resolve which key specs to use: explicit list or all discovered keys with defaults
+    let default_specs: Vec<KeySpec>;
+    let selected: Vec<&KeySpec> = if key_specs.is_empty() {
+        if all_keys.is_empty() {
+            println!("No extra_data keys found in any submission.");
+            return;
+        }
+        default_specs = all_keys
+            .into_iter()
+            .map(|k| KeySpec { key: k, decode: Decode::Raw, ext: None })
+            .collect();
+        default_specs.iter().collect()
+    } else {
+        key_specs.iter().collect()
+    };
+
+    let mut missing_report: Vec<(String, Vec<String>)> = vec![];
+    let mut written: usize = 0;
+
+    for (submission_id, submission) in &submissions {
+        let extra_data = submission.extra_data_map();
+        let label = compute_label(submission_id, submission.submitters(), name_by);
+
+        let missing: Vec<String> = selected
+            .iter()
+            .filter(|spec| !extra_data.contains_key(&spec.key))
+            .map(|spec| spec.key.clone())
+            .collect();
+
+        if !missing.is_empty() {
+            missing_report.push((label.clone(), missing));
+            if skip_missing {
+                continue;
+            }
+        }
+
+        if missing_only {
+            continue;
+        }
+
+        if output.is_none() {
+            println!("{}:", label.bold());
+        }
+
+        for spec in &selected {
+            let value = match extra_data.get(&spec.key) {
+                Some(v) => stringify_yaml_value(v),
+                None => continue,
+            };
+
+            let decoded = match decode_value(&value, &spec.decode) {
+                Ok(d) => d,
+                Err(e) => {
+                    eprintln!(
+                        "{} decoding '{}' for '{}': {}",
+                        "Error".red().bold(),
+                        spec.key,
+                        label,
+                        e
+                    );
+                    continue;
+                }
+            };
+
+            match output {
+                None => {
+                    let display = match &decoded {
+                        DecodeOutput::Text(s) => s.as_str().to_string(),
+                        DecodeOutput::Binary(b) => format!("[binary, {} bytes]", b.len()),
+                    };
+                    println!("  {}: {}", spec.key, display);
+                }
+                Some(out_dir) => {
+                    let filename = match &spec.ext {
+                        Some(ext) => format!("{}.{}", spec.key, ext),
+                        None => spec.key.clone(),
+                    };
+                    let path = match layout {
+                        Layout::Dir => out_dir.join(&label).join(&filename),
+                        Layout::Flat => out_dir.join(format!("{}_{}", label, filename)),
+                    };
+                    if dry_run {
+                        println!("[dry-run] {}", path);
+                        continue;
+                    }
+                    if let Some(parent) = path.parent() {
+                        if let Err(e) = std::fs::create_dir_all(parent) {
+                            eprintln!("{} creating '{}': {}", "Error".red().bold(), parent, e);
+                            continue;
+                        }
+                    }
+                    let result = match decoded {
+                        DecodeOutput::Text(s) => std::fs::write(&path, s),
+                        DecodeOutput::Binary(b) => std::fs::write(&path, b),
+                    };
+                    match result {
+                        Ok(_) => written += 1,
+                        Err(e) => eprintln!("{} writing '{}': {}", "Error".red().bold(), path, e),
+                    }
+                }
+            }
+        }
+
+        if output.is_none() {
+            println!();
+        }
+    }
+
+    // Report
+    if missing_only {
+        if missing_report.is_empty() {
+            println!(
+                "All {} submission(s) have all selected keys.",
+                submissions.len()
+            );
+        } else {
+            println!(
+                "Missing keys in {} of {} submission(s):\n",
+                missing_report.len(),
+                submissions.len()
+            );
+            for (label, keys) in &missing_report {
+                println!("  {}: {}", label, keys.join(", "));
+            }
+        }
+    } else {
+        if output.is_some() && !dry_run {
+            println!("Wrote {} file(s).", written);
+        }
+        if !missing_report.is_empty() {
+            eprintln!(
+                "\n{}: {} submission(s) missing key(s):",
+                "Warning".yellow().bold(),
+                missing_report.len()
+            );
+            for (label, keys) in &missing_report {
+                eprintln!("  {}: {}", label, keys.join(", "));
+            }
+        }
     }
 }
 

--- a/src/cli/handlers.rs
+++ b/src/cli/handlers.rs
@@ -1,15 +1,17 @@
 use camino::Utf8PathBuf;
 use itertools::Itertools;
 use std::collections::BTreeSet;
+use std::io::{self, BufRead, Write};
 
 use colored::Colorize;
 
 use crate::{
     cli::utils::print_group,
     extract::{compute_label, decode_value, stringify_yaml_value, Decode, DecodeOutput, KeySpec, Layout, NameBy},
+    grade::{build_url, done_key, parse_submission_id, substitute_cmd, GradeState},
     gradescope::{
         loaders::{load_export, load_exports},
-        types::{LatestSubmission, SubmissionTrait},
+        types::{LatestSubmission, Submitter, SubmissionTrait},
     },
     rufus::{EmissionsGroup, Grouping},
 };
@@ -97,49 +99,77 @@ pub fn handle_extract(
     skip_missing: bool,
     missing_only: bool,
     dry_run: bool,
+    alongside: bool,
 ) {
-    let submissions: Vec<(String, LatestSubmission)> = filepaths
-        .iter()
-        .flat_map(|fp| {
-            print!("Parsing file {}... ", fp);
-            match load_export(fp) {
-                Ok(export) => {
-                    println!("{}", "DONE".green());
-                    Some(export)
+    // Build batches: (effective_output_dir, submissions).
+    // alongside=true → one batch per source file, output dir = file's parent.
+    // alongside=false → one batch of all submissions, output dir = --output or None (display).
+    let batches: Vec<(Option<Utf8PathBuf>, Vec<(String, LatestSubmission)>)> = if alongside {
+        filepaths
+            .iter()
+            .filter_map(|fp| {
+                print!("Parsing file {}... ", fp);
+                match load_export(fp) {
+                    Ok(export) => {
+                        println!("{}", "DONE".green());
+                        let out_dir = fp
+                            .parent()
+                            .map(|p| Utf8PathBuf::from(p))
+                            .unwrap_or_else(|| Utf8PathBuf::from("."));
+                        Some((Some(out_dir), export.into_iter().collect()))
+                    }
+                    Err(_) => {
+                        println!("{}", "FAILED".red());
+                        None
+                    }
                 }
-                Err(_) => {
-                    println!("{}", "FAILED".red());
-                    None
+            })
+            .collect()
+    } else {
+        let submissions: Vec<(String, LatestSubmission)> = filepaths
+            .iter()
+            .flat_map(|fp| {
+                print!("Parsing file {}... ", fp);
+                match load_export(fp) {
+                    Ok(export) => {
+                        println!("{}", "DONE".green());
+                        Some(export)
+                    }
+                    Err(_) => {
+                        println!("{}", "FAILED".red());
+                        None
+                    }
                 }
-            }
-        })
-        .flat_map(|e| e.into_iter())
-        .collect();
+            })
+            .flat_map(|e| e.into_iter())
+            .collect();
+        vec![(output.clone(), submissions)]
+    };
 
-    if submissions.is_empty() {
+    let total_submissions: usize = batches.iter().map(|(_, s)| s.len()).sum();
+    if total_submissions == 0 {
         eprintln!("No submissions loaded.");
         return;
     }
     println!();
 
-    // Collect all extra_data keys present across all submissions
-    let all_keys: BTreeSet<String> = submissions
+    // Collect all extra_data keys across all batches
+    let all_keys: BTreeSet<String> = batches
         .iter()
-        .flat_map(|(_, s)| s.extra_data_map().into_keys())
+        .flat_map(|(_, subs)| subs.iter().flat_map(|(_, s)| s.extra_data_map().into_keys()))
         .collect();
 
     if list {
+        let all_subs: Vec<&LatestSubmission> =
+            batches.iter().flat_map(|(_, subs)| subs.iter().map(|(_, s)| s)).collect();
         println!(
             "Found {} key(s) across {} submission(s):\n",
             all_keys.len(),
-            submissions.len()
+            all_subs.len()
         );
         for key in &all_keys {
-            let count = submissions
-                .iter()
-                .filter(|(_, s)| s.extra_data_map().contains_key(key))
-                .count();
-            println!("  {}  ({}/{})", key, count, submissions.len());
+            let count = all_subs.iter().filter(|s| s.extra_data_map().contains_key(key)).count();
+            println!("  {}  ({}/{})", key, count, all_subs.len());
         }
         if !all_keys.is_empty() {
             let flags = all_keys
@@ -152,7 +182,7 @@ pub fn handle_extract(
         return;
     }
 
-    // Resolve which key specs to use: explicit list or all discovered keys with defaults
+    // Resolve key specs once: explicit list or all discovered keys
     let default_specs: Vec<KeySpec>;
     let selected: Vec<&KeySpec> = if key_specs.is_empty() {
         if all_keys.is_empty() {
@@ -170,61 +200,62 @@ pub fn handle_extract(
 
     let mut missing_report: Vec<(String, Vec<String>)> = vec![];
     let mut written: usize = 0;
+    let display_mode = !alongside && output.is_none();
 
-    for (submission_id, submission) in &submissions {
-        let extra_data = submission.extra_data_map();
-        let label = compute_label(submission_id, submission.submitters(), name_by);
+    for (out_dir, submissions) in &batches {
+        for (submission_id, submission) in submissions {
+            let extra_data = submission.extra_data_map();
+            let label = compute_label(submission_id, submission.submitters(), name_by);
 
-        let missing: Vec<String> = selected
-            .iter()
-            .filter(|spec| !extra_data.contains_key(&spec.key))
-            .map(|spec| spec.key.clone())
-            .collect();
+            let missing: Vec<String> = selected
+                .iter()
+                .filter(|spec| !extra_data.contains_key(&spec.key))
+                .map(|spec| spec.key.clone())
+                .collect();
 
-        if !missing.is_empty() {
-            missing_report.push((label.clone(), missing));
-            if skip_missing {
-                continue;
-            }
-        }
-
-        if missing_only {
-            continue;
-        }
-
-        if output.is_none() {
-            println!("{}:", label.bold());
-        }
-
-        for spec in &selected {
-            let value = match extra_data.get(&spec.key) {
-                Some(v) => stringify_yaml_value(v),
-                None => continue,
-            };
-
-            let decoded = match decode_value(&value, &spec.decode) {
-                Ok(d) => d,
-                Err(e) => {
-                    eprintln!(
-                        "{} decoding '{}' for '{}': {}",
-                        "Error".red().bold(),
-                        spec.key,
-                        label,
-                        e
-                    );
+            if !missing.is_empty() {
+                missing_report.push((label.clone(), missing));
+                if skip_missing {
                     continue;
                 }
-            };
+            }
 
-            match output {
-                None => {
+            if missing_only {
+                continue;
+            }
+
+            if display_mode {
+                println!("{}:", label.bold());
+            }
+
+            for spec in &selected {
+                let value = match extra_data.get(&spec.key) {
+                    Some(v) => stringify_yaml_value(v),
+                    None => continue,
+                };
+
+                let decoded = match decode_value(&value, &spec.decode) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        eprintln!(
+                            "{} decoding '{}' for '{}': {}",
+                            "Error".red().bold(),
+                            spec.key,
+                            label,
+                            e
+                        );
+                        continue;
+                    }
+                };
+
+                if display_mode {
                     let display = match &decoded {
                         DecodeOutput::Text(s) => s.as_str().to_string(),
                         DecodeOutput::Binary(b) => format!("[binary, {} bytes]", b.len()),
                     };
                     println!("  {}: {}", spec.key, display);
-                }
-                Some(out_dir) => {
+                } else {
+                    let out_dir = out_dir.as_ref().unwrap();
                     let filename = match &spec.ext {
                         Some(ext) => format!("{}.{}", spec.key, ext),
                         None => spec.key.clone(),
@@ -253,32 +284,29 @@ pub fn handle_extract(
                     }
                 }
             }
-        }
 
-        if output.is_none() {
-            println!();
+            if display_mode {
+                println!();
+            }
         }
     }
 
     // Report
     if missing_only {
         if missing_report.is_empty() {
-            println!(
-                "All {} submission(s) have all selected keys.",
-                submissions.len()
-            );
+            println!("All {} submission(s) have all selected keys.", total_submissions);
         } else {
             println!(
                 "Missing keys in {} of {} submission(s):\n",
                 missing_report.len(),
-                submissions.len()
+                total_submissions
             );
             for (label, keys) in &missing_report {
                 println!("  {}: {}", label, keys.join(", "));
             }
         }
     } else {
-        if output.is_some() && !dry_run {
+        if !display_mode && !dry_run {
             println!("Wrote {} file(s).", written);
         }
         if !missing_report.is_empty() {
@@ -329,4 +357,278 @@ pub fn hunt<'a>(groups: &'a [EmissionsGroup<'a>], k: usize, exact: bool) -> Vec<
     }
 
     return groupings;
+}
+
+// ── grade ────────────────────────────────────────────────────────────────────
+
+struct Step {
+    submission_id: String,
+    dir: Utf8PathBuf,
+    sub_idx: usize,
+}
+
+fn run_cmd(template: &str, dir: &str) {
+    let cmd = substitute_cmd(template, dir);
+    println!("Running: {}", cmd.italic());
+
+    #[cfg(unix)]
+    let result = std::process::Command::new("sh").args(["-c", &cmd]).status();
+    #[cfg(windows)]
+    let result = std::process::Command::new("cmd").args(["/C", &cmd]).status();
+
+    match result {
+        Ok(s) if !s.success() => eprintln!(
+            "{}: command exited with {}",
+            "Warning".yellow().bold(),
+            s
+        ),
+        Err(e) => eprintln!("{} running command: {}", "Error".red().bold(), e),
+        _ => {}
+    }
+}
+
+pub fn handle_grade(
+    dir_arg: &Option<Utf8PathBuf>,
+    course_arg: &Option<String>,
+    assignment_arg: &Option<String>,
+    export: &Option<Utf8PathBuf>,
+    cmd: &Option<String>,
+    state_path: &Option<Utf8PathBuf>,
+    reset: bool,
+) {
+    // Resolve state file path: explicit > <dir>/.rufus-grade
+    let state_file = state_path.clone().or_else(|| {
+        dir_arg.as_ref().map(|d| d.join(".rufus-grade"))
+    });
+
+    // Try loading existing state to fill in missing params
+    let existing_state: Option<GradeState> = state_file.as_ref().and_then(|p| {
+        if !reset && p.exists() {
+            match GradeState::load(p.as_std_path()) {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    eprintln!("{} loading state: {}", "Error".red().bold(), e);
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    });
+
+    // Resolve final params: CLI args take priority, state fills gaps
+    let dir: Utf8PathBuf = match dir_arg.clone()
+        .or_else(|| existing_state.as_ref().map(|s| Utf8PathBuf::from(&s.dir)))
+    {
+        Some(d) => d,
+        None => {
+            eprintln!("{}: <dir> is required on first run (no state file found).", "Error".red().bold());
+            return;
+        }
+    };
+    let course: String = match course_arg.clone()
+        .or_else(|| existing_state.as_ref().map(|s| s.course_id.clone()))
+    {
+        Some(c) => c,
+        None => {
+            eprintln!("{}: --course is required on first run.", "Error".red().bold());
+            return;
+        }
+    };
+    let assignment: String = match assignment_arg.clone()
+        .or_else(|| existing_state.as_ref().map(|s| s.assignment_id.clone()))
+    {
+        Some(a) => a,
+        None => {
+            eprintln!("{}: --assignment is required on first run.", "Error".red().bold());
+            return;
+        }
+    };
+
+    // Now that we have dir, resolve state file if it wasn't explicit
+    let state_file = state_file.unwrap_or_else(|| dir.join(".rufus-grade"));
+
+    // Load submitter info from export if provided
+    let submitter_map: std::collections::HashMap<String, Vec<Submitter>> =
+        if let Some(export_path) = export {
+            match load_export(export_path) {
+                Ok(exp) => exp
+                    .into_iter()
+                    .filter_map(|(k, v)| {
+                        parse_submission_id(&k).map(|id| (id, v.submitters().clone()))
+                    })
+                    .collect(),
+                Err(e) => {
+                    eprintln!("{} loading export: {}", "Error".red().bold(), e);
+                    std::collections::HashMap::new()
+                }
+            }
+        } else {
+            std::collections::HashMap::new()
+        };
+
+    // Walk and sort submission directories
+    let mut submissions: Vec<(String, Utf8PathBuf)> = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .filter_map(|e| {
+                let name = e.file_name().to_string_lossy().into_owned();
+                let path = Utf8PathBuf::from(e.path().to_string_lossy().as_ref());
+                parse_submission_id(&name).map(|id| (id, path))
+            })
+            .collect(),
+        Err(e) => {
+            eprintln!("{} reading directory '{}': {}", "Error".red().bold(), dir, e);
+            return;
+        }
+    };
+    submissions.sort_by(|a, b| a.0.cmp(&b.0));
+
+    if submissions.is_empty() {
+        eprintln!("No submission directories found in '{}'.", dir);
+        return;
+    }
+
+    // Validate consistency if resuming, then use or create state
+    let mut state = match existing_state {
+        Some(s) => {
+            if !s.is_consistent(&course, &assignment, dir.as_str()) {
+                eprintln!(
+                    "{}: state file is from a different session.",
+                    "Error".red().bold()
+                );
+                eprintln!("  Saved:   course={}, assignment={}, dir={}", s.course_id, s.assignment_id, s.dir);
+                eprintln!("  Current: course={}, assignment={}, dir={}", course, assignment, dir);
+                eprintln!("Use --reset to start over.");
+                return;
+            }
+            println!("Resuming — {} submission(s) already done.\n", s.done.len());
+            s
+        }
+        None => GradeState::new(course.clone(), assignment.clone(), dir.to_string()),
+    };
+
+    let steps: Vec<Step> = submissions
+        .iter()
+        .enumerate()
+        .map(|(si, (sub_id, sub_dir))| Step {
+            submission_id: sub_id.clone(),
+            dir: sub_dir.clone(),
+            sub_idx: si,
+        })
+        .collect();
+
+    let n_subs = submissions.len();
+    let mut cursor: usize = 0;
+    let mut last_cmd_sub: Option<String> = None;
+
+    while cursor < steps.len() {
+        let step = &steps[cursor];
+        let key = done_key(&step.submission_id);
+
+        if state.is_done(&key) {
+            cursor += 1;
+            continue;
+        }
+
+        // Header
+        println!(
+            "\n{}",
+            format!(
+                "=== {}  ({} / {}) ===",
+                step.submission_id,
+                step.sub_idx + 1,
+                n_subs
+            )
+            .bold()
+        );
+        if let Some(subs) = submitter_map.get(&step.submission_id) {
+            for s in subs {
+                let sid = s.sid.as_deref().unwrap_or("no SID");
+                println!("    {}  ·  {}  ·  SID {}", s.name, s.email, sid);
+            }
+        }
+        println!();
+
+        // Run command once per submission
+        if let Some(template) = cmd {
+            if last_cmd_sub.as_deref() != Some(&step.submission_id) {
+                run_cmd(template, step.dir.as_str());
+                last_cmd_sub = Some(step.submission_id.clone());
+                println!();
+            }
+        }
+
+        // Open browser
+        let url = build_url(&course, &assignment, &step.submission_id);
+        println!("Opening: {}", url.underline());
+        if let Err(e) = open::that(&url) {
+            eprintln!("{} opening browser: {}", "Warning".yellow().bold(), e);
+        }
+
+        // Prompt loop
+        let show_rerun = cmd.is_some();
+        loop {
+            println!();
+            if show_rerun {
+                print!("[Enter] done  [s] skip  [r] re-run  [b] back  [q] quit\n> ");
+            } else {
+                print!("[Enter] done  [s] skip  [b] back  [q] quit\n> ");
+            }
+            io::stdout().flush().ok();
+
+            let mut input = String::new();
+            io::stdin().lock().read_line(&mut input).ok();
+
+            match input.trim() {
+                "" => {
+                    state.mark_done(key.clone());
+                    if let Err(e) = state.save(state_file.as_std_path()) {
+                        eprintln!("{} saving state: {}", "Warning".yellow().bold(), e);
+                    }
+                    cursor += 1;
+                    break;
+                }
+                "s" => {
+                    cursor += 1;
+                    break;
+                }
+                "r" => {
+                    if let Some(template) = cmd {
+                        run_cmd(template, step.dir.as_str());
+                        open::that(&url).ok();
+                    } else {
+                        println!("No --cmd specified.");
+                    }
+                }
+                "b" => {
+                    if cursor == 0 {
+                        println!("Already at the first submission.");
+                    } else {
+                        cursor -= 1;
+                        let prev_key = done_key(&steps[cursor].submission_id);
+                        state.unmark_done(&prev_key);
+                        // Also reset last_cmd_sub so the command re-runs
+                        last_cmd_sub = None;
+                        if let Err(e) = state.save(state_file.as_std_path()) {
+                            eprintln!("{} saving state: {}", "Warning".yellow().bold(), e);
+                        }
+                    }
+                    break;
+                }
+                "q" => {
+                    println!("\nProgress saved to '{}'.", state_file);
+                    return;
+                }
+                _ => println!("Unknown input. Try Enter, s, r, b, or q."),
+            }
+        }
+    }
+
+    println!(
+        "\n{} All {} submission(s) graded.",
+        "Done!".green().bold(),
+        n_subs
+    );
 }

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -1,0 +1,390 @@
+use base64::engine::general_purpose::{STANDARD as B64_STANDARD, URL_SAFE as B64_URL_SAFE};
+use base64::Engine;
+use clap::ValueEnum;
+
+use crate::gradescope::types::Submitter;
+
+#[derive(Debug, Clone)]
+pub struct KeySpec {
+    pub key: String,
+    pub decode: Decode,
+    pub ext: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Decode {
+    Raw,
+    Base64,
+    Base64Url,
+    Hex,
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum Layout {
+    Dir,
+    Flat,
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum NameBy {
+    #[value(name = "submission_id")]
+    SubmissionId,
+    Name,
+    Email,
+    Sid,
+}
+
+/// Parses a `--key` flag value of the form `name[:decode[:ext]]`.
+/// Any segment may be empty (e.g. `checksum::sha256` → raw decode, .sha256 ext).
+pub fn parse_key_spec(s: &str) -> Result<KeySpec, String> {
+    let parts: Vec<&str> = s.splitn(3, ':').collect();
+    let key = parts[0].to_string();
+    if key.is_empty() {
+        return Err("Key name cannot be empty".to_string());
+    }
+    let decode = match parts.get(1).copied().unwrap_or("") {
+        "" | "none" | "raw" => Decode::Raw,
+        "base64" => Decode::Base64,
+        "base64url" => Decode::Base64Url,
+        "hex" => Decode::Hex,
+        other => {
+            return Err(format!(
+                "Unknown decode '{}'. Valid options: raw, none, base64, base64url, hex",
+                other
+            ))
+        }
+    };
+    let ext = parts
+        .get(2)
+        .copied()
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    Ok(KeySpec { key, decode, ext })
+}
+
+pub enum DecodeOutput {
+    Text(String),
+    Binary(Vec<u8>),
+}
+
+pub fn decode_value(value: &str, decode: &Decode) -> Result<DecodeOutput, String> {
+    match decode {
+        Decode::Raw => Ok(DecodeOutput::Text(value.to_string())),
+        Decode::Base64 => {
+            let bytes = B64_STANDARD
+                .decode(value.trim())
+                .map_err(|e| format!("base64 decode error: {}", e))?;
+            Ok(DecodeOutput::Binary(bytes))
+        }
+        Decode::Base64Url => {
+            let bytes = B64_URL_SAFE
+                .decode(value.trim())
+                .map_err(|e| format!("base64url decode error: {}", e))?;
+            Ok(DecodeOutput::Binary(bytes))
+        }
+        Decode::Hex => {
+            let s = value
+                .trim()
+                .trim_start_matches("0x")
+                .trim_start_matches("0X");
+            if s.len() % 2 != 0 {
+                return Err("hex decode error: odd number of hex digits".to_string());
+            }
+            let bytes = (0..s.len())
+                .step_by(2)
+                .map(|i| {
+                    u8::from_str_radix(&s[i..i + 2], 16)
+                        .map_err(|e| format!("hex decode error at offset {}: {}", i, e))
+                })
+                .collect::<Result<Vec<u8>, String>>()?;
+            Ok(DecodeOutput::Binary(bytes))
+        }
+    }
+}
+
+/// Converts a serde_yaml Value to a String for writing or decoding.
+/// Maps/sequences are serialized as trimmed YAML.
+pub fn stringify_yaml_value(value: &serde_yaml::Value) -> String {
+    match value {
+        serde_yaml::Value::String(s) => s.clone(),
+        serde_yaml::Value::Bool(b) => b.to_string(),
+        serde_yaml::Value::Number(n) => n.to_string(),
+        serde_yaml::Value::Null => String::new(),
+        other => serde_yaml::to_string(other)
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+    }
+}
+
+/// Replaces characters unsafe for use in file/directory names with `_`.
+pub fn sanitize_for_path(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Computes the filesystem label for a submission based on `--name-by`.
+/// Multi-submitter groups are joined with `_`. Falls back to `submission_id`
+/// if the submitter list is empty.
+pub fn compute_label(submission_id: &str, submitters: &[Submitter], name_by: &NameBy) -> String {
+    let join = |parts: Vec<String>| {
+        if parts.is_empty() {
+            sanitize_for_path(submission_id)
+        } else {
+            parts.join("_")
+        }
+    };
+    match name_by {
+        NameBy::SubmissionId => sanitize_for_path(submission_id),
+        NameBy::Name => join(
+            submitters
+                .iter()
+                .map(|s| sanitize_for_path(&s.name))
+                .collect(),
+        ),
+        NameBy::Email => join(
+            submitters
+                .iter()
+                .map(|s| sanitize_for_path(&s.email))
+                .collect(),
+        ),
+        NameBy::Sid => join(
+            submitters
+                .iter()
+                .map(|s| sanitize_for_path(s.sid.as_deref().unwrap_or("unknown")))
+                .collect(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sub(name: &str, email: &str, sid: Option<&str>) -> Submitter {
+        Submitter {
+            name: name.to_string(),
+            email: email.to_string(),
+            sid: sid.map(str::to_string),
+        }
+    }
+
+    // --- parse_key_spec ---
+
+    #[test]
+    fn parse_key_only() {
+        let k = parse_key_spec("level_uf2").unwrap();
+        assert_eq!(k.key, "level_uf2");
+        assert_eq!(k.decode, Decode::Raw);
+        assert_eq!(k.ext, None);
+    }
+
+    #[test]
+    fn parse_key_with_decode() {
+        let k = parse_key_spec("level_uf2:base64").unwrap();
+        assert_eq!(k.decode, Decode::Base64);
+        assert_eq!(k.ext, None);
+    }
+
+    #[test]
+    fn parse_key_full() {
+        let k = parse_key_spec("level_uf2:base64:uf2").unwrap();
+        assert_eq!(k.key, "level_uf2");
+        assert_eq!(k.decode, Decode::Base64);
+        assert_eq!(k.ext, Some("uf2".to_string()));
+    }
+
+    #[test]
+    fn parse_key_empty_decode_with_ext() {
+        // checksum::sha256 → raw decode, .sha256 ext
+        let k = parse_key_spec("checksum::sha256").unwrap();
+        assert_eq!(k.key, "checksum");
+        assert_eq!(k.decode, Decode::Raw);
+        assert_eq!(k.ext, Some("sha256".to_string()));
+    }
+
+    #[test]
+    fn parse_key_none_decode_alias() {
+        let k = parse_key_spec("foo:none:txt").unwrap();
+        assert_eq!(k.decode, Decode::Raw);
+    }
+
+    #[test]
+    fn parse_key_hex_decode() {
+        let k = parse_key_spec("data:hex:bin").unwrap();
+        assert_eq!(k.decode, Decode::Hex);
+        assert_eq!(k.ext, Some("bin".to_string()));
+    }
+
+    #[test]
+    fn parse_key_base64url() {
+        let k = parse_key_spec("token:base64url").unwrap();
+        assert_eq!(k.decode, Decode::Base64Url);
+    }
+
+    #[test]
+    fn parse_key_empty_name_errors() {
+        assert!(parse_key_spec(":base64:uf2").is_err());
+    }
+
+    #[test]
+    fn parse_key_unknown_decode_errors() {
+        assert!(parse_key_spec("key:magic").is_err());
+    }
+
+    // --- decode_value ---
+
+    #[test]
+    fn decode_raw_passthrough() {
+        match decode_value("hello world", &Decode::Raw).unwrap() {
+            DecodeOutput::Text(s) => assert_eq!(s, "hello world"),
+            _ => panic!("expected text"),
+        }
+    }
+
+    #[test]
+    fn decode_base64_bytes() {
+        // "hello" → "aGVsbG8="
+        match decode_value("aGVsbG8=", &Decode::Base64).unwrap() {
+            DecodeOutput::Binary(b) => assert_eq!(b, b"hello"),
+            _ => panic!("expected binary"),
+        }
+    }
+
+    #[test]
+    fn decode_base64_strips_whitespace() {
+        match decode_value("  aGVsbG8=  ", &Decode::Base64).unwrap() {
+            DecodeOutput::Binary(b) => assert_eq!(b, b"hello"),
+            _ => panic!("expected binary"),
+        }
+    }
+
+    #[test]
+    fn decode_base64_invalid_errors() {
+        assert!(decode_value("not!!valid", &Decode::Base64).is_err());
+    }
+
+    #[test]
+    fn decode_hex_bytes() {
+        // "hello" → "68656c6c6f"
+        match decode_value("68656c6c6f", &Decode::Hex).unwrap() {
+            DecodeOutput::Binary(b) => assert_eq!(b, b"hello"),
+            _ => panic!("expected binary"),
+        }
+    }
+
+    #[test]
+    fn decode_hex_0x_prefix() {
+        match decode_value("0x68656c6c6f", &Decode::Hex).unwrap() {
+            DecodeOutput::Binary(b) => assert_eq!(b, b"hello"),
+            _ => panic!("expected binary"),
+        }
+    }
+
+    #[test]
+    fn decode_hex_odd_length_errors() {
+        assert!(decode_value("abc", &Decode::Hex).is_err());
+    }
+
+    #[test]
+    fn decode_hex_invalid_chars_errors() {
+        assert!(decode_value("zz", &Decode::Hex).is_err());
+    }
+
+    // --- stringify_yaml_value ---
+
+    #[test]
+    fn stringify_string_value() {
+        let v = serde_yaml::Value::String("hello".to_string());
+        assert_eq!(stringify_yaml_value(&v), "hello");
+    }
+
+    #[test]
+    fn stringify_number_value() {
+        let v = serde_yaml::Value::Number(serde_yaml::Number::from(42i64));
+        assert_eq!(stringify_yaml_value(&v), "42");
+    }
+
+    #[test]
+    fn stringify_bool_value() {
+        assert_eq!(stringify_yaml_value(&serde_yaml::Value::Bool(true)), "true");
+    }
+
+    #[test]
+    fn stringify_null_value() {
+        assert_eq!(stringify_yaml_value(&serde_yaml::Value::Null), "");
+    }
+
+    // --- sanitize_for_path ---
+
+    #[test]
+    fn sanitize_spaces_to_underscores() {
+        assert_eq!(sanitize_for_path("John Doe"), "John_Doe");
+    }
+
+    #[test]
+    fn sanitize_email_at_sign() {
+        assert_eq!(sanitize_for_path("jdoe@ufl.edu"), "jdoe_ufl.edu");
+    }
+
+    #[test]
+    fn sanitize_alphanumeric_dash_dot_unchanged() {
+        assert_eq!(sanitize_for_path("abc-123.bin"), "abc-123.bin");
+    }
+
+    // --- compute_label ---
+
+    #[test]
+    fn label_uses_submission_id() {
+        let subs = vec![sub("John", "j@ufl.edu", Some("11111"))];
+        assert_eq!(
+            compute_label("99999", &subs, &NameBy::SubmissionId),
+            "99999"
+        );
+    }
+
+    #[test]
+    fn label_by_name_single() {
+        let subs = vec![sub("John Doe", "j@ufl.edu", Some("11111"))];
+        assert_eq!(compute_label("99999", &subs, &NameBy::Name), "John_Doe");
+    }
+
+    #[test]
+    fn label_by_name_multi_submitter() {
+        let subs = vec![
+            sub("John Doe", "j@ufl.edu", Some("11111")),
+            sub("Jane Smith", "s@ufl.edu", Some("22222")),
+        ];
+        assert_eq!(
+            compute_label("99999", &subs, &NameBy::Name),
+            "John_Doe_Jane_Smith"
+        );
+    }
+
+    #[test]
+    fn label_by_email() {
+        let subs = vec![sub("John", "jdoe@ufl.edu", None)];
+        assert_eq!(
+            compute_label("99999", &subs, &NameBy::Email),
+            "jdoe_ufl.edu"
+        );
+    }
+
+    #[test]
+    fn label_by_sid_missing_falls_back_to_unknown() {
+        let subs = vec![sub("John", "j@ufl.edu", None)];
+        assert_eq!(compute_label("99999", &subs, &NameBy::Sid), "unknown");
+    }
+
+    #[test]
+    fn label_empty_submitters_falls_back_to_submission_id() {
+        assert_eq!(compute_label("99999", &[], &NameBy::Name), "99999");
+    }
+}

--- a/src/grade/mod.rs
+++ b/src/grade/mod.rs
@@ -1,0 +1,210 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::Path;
+
+const GRADESCOPE_BASE: &str = "https://www.gradescope.com";
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct GradeState {
+    pub course_id: String,
+    pub assignment_id: String,
+    pub dir: String,
+    pub done: HashSet<String>,
+}
+
+impl GradeState {
+    pub fn new(course_id: String, assignment_id: String, dir: String) -> Self {
+        GradeState { course_id, assignment_id, dir, done: HashSet::new() }
+    }
+
+    pub fn load(path: &Path) -> Result<Self, String> {
+        let data = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+        serde_json::from_str(&data).map_err(|e| e.to_string())
+    }
+
+    pub fn save(&self, path: &Path) -> Result<(), String> {
+        let data = serde_json::to_string_pretty(self).map_err(|e| e.to_string())?;
+        std::fs::write(path, data).map_err(|e| e.to_string())
+    }
+
+    pub fn mark_done(&mut self, key: String) {
+        self.done.insert(key);
+    }
+
+    pub fn unmark_done(&mut self, key: &str) {
+        self.done.remove(key);
+    }
+
+    pub fn is_done(&self, key: &str) -> bool {
+        self.done.contains(key)
+    }
+
+    pub fn is_consistent(&self, course_id: &str, assignment_id: &str, dir: &str) -> bool {
+        self.course_id == course_id && self.assignment_id == assignment_id && self.dir == dir
+    }
+}
+
+pub fn done_key(submission_id: &str) -> String {
+    submission_id.to_string()
+}
+
+/// Parses the numeric Gradescope submission ID from a directory name.
+/// Expects the `submission_{digits}` format produced by `extract --name-by submission_id`.
+pub fn parse_submission_id(dir_name: &str) -> Option<String> {
+    dir_name
+        .strip_prefix("submission_")
+        .filter(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()))
+        .map(str::to_string)
+}
+
+pub fn build_url(course_id: &str, assignment_id: &str, submission_id: &str) -> String {
+    format!(
+        "{}/courses/{}/assignments/{}/submissions/{}",
+        GRADESCOPE_BASE, course_id, assignment_id, submission_id
+    )
+}
+
+/// Substitutes `{dir}` and `{file:name}` placeholders in a command template.
+pub fn substitute_cmd(template: &str, dir: &str) -> String {
+    let s = template.replace("{dir}", dir);
+    let re = regex::Regex::new(r"\{file:([^}]+)\}").unwrap();
+    re.replace_all(&s, |caps: &regex::Captures| format!("{}/{}", dir, &caps[1]))
+        .into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- parse_submission_id ---
+
+    #[test]
+    fn parse_id_valid() {
+        assert_eq!(
+            parse_submission_id("submission_403094485"),
+            Some("403094485".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_id_missing_prefix() {
+        assert_eq!(parse_submission_id("403094485"), None);
+    }
+
+    #[test]
+    fn parse_id_non_numeric_suffix() {
+        assert_eq!(parse_submission_id("submission_abc"), None);
+    }
+
+    #[test]
+    fn parse_id_empty_suffix() {
+        assert_eq!(parse_submission_id("submission_"), None);
+    }
+
+    #[test]
+    fn parse_id_mixed_suffix() {
+        assert_eq!(parse_submission_id("submission_123abc"), None);
+    }
+
+    // --- build_url ---
+
+    #[test]
+    fn url_builds_correctly() {
+        assert_eq!(
+            build_url("1217863", "7420607", "403094485"),
+            "https://www.gradescope.com/courses/1217863/assignments/7420607/submissions/403094485"
+        );
+    }
+
+    // --- substitute_cmd ---
+
+    #[test]
+    fn cmd_substitutes_dir() {
+        assert_eq!(
+            substitute_cmd("echo {dir}", "/tmp/foo"),
+            "echo /tmp/foo"
+        );
+    }
+
+    #[test]
+    fn cmd_substitutes_file() {
+        assert_eq!(
+            substitute_cmd("picotool load {file:level_uf2.uf2}", "/tmp/foo"),
+            "picotool load /tmp/foo/level_uf2.uf2"
+        );
+    }
+
+    #[test]
+    fn cmd_substitutes_both() {
+        assert_eq!(
+            substitute_cmd("cp {file:out.bin} {dir}/backup.bin", "/tmp/foo"),
+            "cp /tmp/foo/out.bin /tmp/foo/backup.bin"
+        );
+    }
+
+    #[test]
+    fn cmd_no_placeholders_unchanged() {
+        assert_eq!(substitute_cmd("ls -la", "/tmp/foo"), "ls -la");
+    }
+
+    // --- done_key ---
+
+    #[test]
+    fn done_key_is_submission_id() {
+        assert_eq!(done_key("403094485"), "403094485");
+    }
+
+    // --- GradeState ---
+
+    #[test]
+    fn state_mark_and_check_done() {
+        let mut s = GradeState::new("c".into(), "a".into(), "/tmp".into());
+        assert!(!s.is_done("403094485"));
+        s.mark_done("403094485".to_string());
+        assert!(s.is_done("403094485"));
+    }
+
+    #[test]
+    fn state_unmark_done() {
+        let mut s = GradeState::new("c".into(), "a".into(), "/tmp".into());
+        s.mark_done("403094485".to_string());
+        s.unmark_done("403094485");
+        assert!(!s.is_done("403094485"));
+    }
+
+    #[test]
+    fn state_is_consistent_matching() {
+        let s = GradeState::new("1217863".into(), "7420607".into(), "/tmp/uf2s".into());
+        assert!(s.is_consistent("1217863", "7420607", "/tmp/uf2s"));
+    }
+
+    #[test]
+    fn state_is_consistent_different_course() {
+        let s = GradeState::new("1217863".into(), "7420607".into(), "/tmp/uf2s".into());
+        assert!(!s.is_consistent("9999999", "7420607", "/tmp/uf2s"));
+    }
+
+    #[test]
+    fn state_is_consistent_different_assignment() {
+        let s = GradeState::new("1217863".into(), "7420607".into(), "/tmp/uf2s".into());
+        assert!(!s.is_consistent("1217863", "9999999", "/tmp/uf2s"));
+    }
+
+    #[test]
+    fn state_is_consistent_different_dir() {
+        let s = GradeState::new("1217863".into(), "7420607".into(), "/tmp/uf2s".into());
+        assert!(!s.is_consistent("1217863", "7420607", "/tmp/other"));
+    }
+
+    #[test]
+    fn state_roundtrips_json() {
+        let mut s = GradeState::new("1217863".into(), "7420607".into(), "/tmp/uf2s".into());
+        s.mark_done("403094485".to_string());
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        s.save(&path).unwrap();
+        let loaded = GradeState::load(&path).unwrap();
+        assert_eq!(s, loaded);
+    }
+}

--- a/src/gradescope/types.rs
+++ b/src/gradescope/types.rs
@@ -21,6 +21,33 @@ pub trait SubmissionTrait {
     fn status(&self) -> &String;
     fn results(&self) -> &Option<Results>;
 
+    fn extra_data_map(&self) -> HashMap<String, serde_yaml::Value> {
+        let extract_mapping = |v: &serde_yaml::Value| -> Vec<(String, serde_yaml::Value)> {
+            match v {
+                serde_yaml::Value::Mapping(m) => m
+                    .iter()
+                    .filter_map(|(k, v)| {
+                        if let serde_yaml::Value::String(key) = k {
+                            Some((key.clone(), v.clone()))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect(),
+                _ => vec![],
+            }
+        };
+        match self.results() {
+            Some(Results::Processed(r)) => r
+                .tests
+                .iter()
+                .filter_map(|t| t.extra_data.as_ref())
+                .flat_map(extract_mapping)
+                .collect(),
+            _ => HashMap::new(),
+        }
+    }
+
     fn parse_emissions<'a>(&'a self) -> EmissionsGroup<'a>
     where
         Self: Sized,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod extract;
+mod grade;
 mod gradescope;
 mod rufus;
 
@@ -35,6 +36,7 @@ fn main() {
             skip_missing,
             missing_only,
             dry_run,
+            alongside,
         } => cli::handlers::handle_extract(
             filepaths,
             keys,
@@ -45,6 +47,24 @@ fn main() {
             *skip_missing,
             *missing_only,
             *dry_run,
+            *alongside,
+        ),
+        Command::Grade {
+            dir,
+            course,
+            assignment,
+            export,
+            cmd,
+            state,
+            reset,
+        } => cli::handlers::handle_grade(
+            dir,         // Option<Utf8PathBuf>
+            course,      // Option<String>
+            assignment,  // Option<String>
+            export,
+            cmd,
+            state,
+            *reset,
         ),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod extract;
 mod gradescope;
 mod rufus;
 
@@ -23,6 +24,27 @@ fn main() {
             &show_emissions,
             &(*min_size as usize),
             &exact,
+        ),
+        Command::Extract {
+            filepaths,
+            keys,
+            output,
+            layout,
+            name_by,
+            list,
+            skip_missing,
+            missing_only,
+            dry_run,
+        } => cli::handlers::handle_extract(
+            filepaths,
+            keys,
+            output,
+            layout,
+            name_by,
+            *list,
+            *skip_missing,
+            *missing_only,
+            *dry_run,
         ),
     }
 }


### PR DESCRIPTION
## Summary

- **`extract`**: pulls `extra_data` fields from Gradescope export YAMLs — supports key selection, decode (raw/base64/base64url/hex), file extension hints, `dir`/`flat` output layouts, `--name-by` labeling, `--list`, `--skip-missing`, `--missing-only`, `--dry-run`, and `--alongside`/`-A` to write files next to the source YAML.
- **`grade`**: walks a directory of extracted submissions, opens each Gradescope grading page in the browser, optionally runs a command per submission (with `{dir}` / `{file:name}` placeholders), and saves resume state to `.rufus-grade`.
- README overhauled to document all four commands with flag tables, key syntax, and a full extract → grade workflow example.
- Version bumped to 1.1.0.

## Test plan

- [ ] `cargo test` passes (50 tests)
- [ ] `rufus extract <export> --list` shows available keys
- [ ] `rufus extract <export> --key level_uf2:base64:uf2 -o ./out/` writes files correctly
- [ ] `rufus extract <export> --key level_uf2:base64:uf2 -A` writes files alongside the YAML
- [ ] `rufus grade ./out/ -c <id> -a <id>` opens browser and saves state
- [ ] Quitting and re-running resumes from the correct position
- [ ] `--reset` ignores saved state and starts over

🤖 Generated with [Claude Code](https://claude.com/claude-code)